### PR TITLE
Modifying JSON

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,332 @@
+# sqlparse - the SQL parser written in Erlang
+
+[![Build Status](https://travis-ci.org/walter-weinmann/sqlparse.svg?branch=master)](https://travis-ci.org/walter-weinmann/sqlparse)
+
+# Release Notes
+
+## Version x.x.x
+
+Release Date: 03.05.2017 - Grammar as of 30.04.2017
+
+### Pure grammar changes
+
+- **APPROXNUM**
+
+```
+New: ((([\.][0-9]+)|([0-9]+[\.]?[0-9]*))[eE]?[+-]?[0-9]*[fFdD]?)
+ 
+Old: (([0-9]+\.[0-9]+([eE][\+\-]?[0-9]+)*))
+```
+
+- **JSON**
+
+```
+New: (\|[:{\[#]([^\|]*)+\|)
+ 
+Old: ([A-Za-z0-9_\.]+([:#\[\{]+|([\s\t\n\r]*[#\[\{]+))[A-Za-z0-9_\.\:\(\)\[\]\{\}\#\,\|\-\+\*\/\\%\s\t\n\r]*)
+```
+
+### Grammar and parse tree changes
+
+- **between_predicate**
+
+```
+New: between_predicate -> scalar_exp NOT BETWEEN scalar_exp AND scalar_exp                           : {'not between', '$1', '$4', '$6'}.
+ 
+Old: between_predicate -> scalar_exp NOT BETWEEN scalar_exp AND scalar_exp                           : {'not', {'between', '$1', '$4', '$6'}}.
+```
+
+- **case_when_exp**
+
+```
+New: case_when_exp -> '(' case_when_exp ')'                                                          : {'$2', "("}.
+ 
+Old: case_when_exp -> '(' case_when_exp ')'                                                          : '$2'.
+```
+
+- **case_when_opt_as_exp**
+
+```
+New: case_when_opt_as_exp -> case_when_exp    NAME                                                   : {as, '$1', unwrap_bin('$2'), " "}.
+     case_when_opt_as_exp -> case_when_exp AS NAME                                                   : {as, '$1', unwrap_bin('$3'), " as "}.
+ 
+Old: case_when_opt_as_exp -> case_when_exp NAME                                                      : {as, '$1', unwrap_bin('$2')}.
+     case_when_opt_as_exp -> case_when_exp AS NAME                                                   : {as, '$1', unwrap_bin('$3')}. 
+```
+
+- **column_ref**
+
+```
+New: column_ref -> JSON                                                                              : {jp, jpparse('$1')}.
+     column_ref -> NAME     JSON                                                                     : {jp, list_to_binary(unwrap('$1')), jpparse('$2')}.
+     column_ref -> NAME '.' NAME     JSON                                                            : {jp, list_to_binary([unwrap('$1'),".",unwrap('$3')]), jpparse('$4')}.
+ 
+Old: column_ref -> JSON                                                                              : jpparse('$1').
+     column_ref -> NAME '.' JSON                                                                     : jpparse(list_to_binary([unwrap('$1'),".",unwrap('$3')])).
+     column_ref -> NAME '.' NAME '.' JSON                                                            : jpparse(list_to_binary([unwrap('$1'),".",unwrap('$3'),".",unwrap('$5')])).
+
+```
+
+- **comparison_predicate**
+
+```
+New: n/a
+ 
+Old: comparison_predicate -> scalar_exp COMPARISON subquery                                          : {unwrap('$2'), '$1', '$3'}.
+```
+
+- **create_index_spec_items**
+
+```
+New: create_index_spec_items -> JSON                                                                 : [{jp, jpparse('$1')}].
+     create_index_spec_items -> JSON '|' create_index_spec_items                                     : [{jp, jpparse('$1')} | '$3'].
+ 
+Old: create_index_spec_items -> JSON                                                                 : [jpparse('$1')].
+     create_index_spec_items -> JSON '|' create_index_spec_items                                     : [jpparse('$1') | '$3'].
+```
+
+- **data_type**
+
+```
+New: data_type -> NAME '(' opt_sgn_num ')'                                                           : {unwrap_bin('$1'), "(", '$3'}.
+     data_type -> NAME '(' opt_sgn_num ',' opt_sgn_num ')'                                           : {unwrap_bin('$1'), "(", '$3', '$5'}.
+ 
+Old: data_type -> NAME '(' opt_sgn_num ')'                                                           : {unwrap_bin('$1'), '$3'}.
+     data_type -> NAME '(' opt_sgn_num ',' opt_sgn_num ')'                                           : {unwrap_bin('$1'), '$3', '$5'}.
+
+```
+
+- **drop_table_def**
+
+```
+New: drop_table_def -> DROP      TABLE opt_exists table_list opt_restrict_cascade                    : {'drop table', {'tables', '$4'}, '$3', '$5', <<>>}.
+     drop_table_def -> DROP NAME TABLE opt_exists table_list opt_restrict_cascade                    : {'drop table', {'tables', '$5'}, '$4', '$6', unwrap_bin('$2')}.
+ 
+Old: drop_table_def -> DROP tbl_type TABLE opt_exists table_list opt_restrict_cascade                : {'drop table', {'tables', '$5'}, '$4', '$6', '$2'}.
+```
+
+- **db_user_proxy**
+
+```
+New: n/a
+ 
+Old: db_user_proxy -> '$empty'                                                                      : {}.
+
+```
+
+- **from_column_commalist**
+
+```
+New: from_column -> table_ref                                                                        : ['$1'].
+     from_column -> '(' join_clause ')'                                                              : {['$2'], "("}.
+     from_column -> join_clause                                                                      : ['$1'].
+ 
+     from_column_commalist ->                           from_column                                  :        ['$1'].
+     from_column_commalist -> from_column_commalist ',' from_column                                  : '$1'++ ['$3'].
+ 
+Old: from_commalist -> table_ref                                                                     : ['$1'].
+     from_commalist -> '(' join_clause ')'                                                           : ['$2'].
+     from_commalist -> join_clause                                                                   : ['$1'].
+     from_commalist -> from_commalist ',' from_commalist                                             : '$1'++'$3'.
+```
+
+- **fun_arg**
+
+```
+New: n/a
+ 
+Old: fun_arg -> '+' literal                                                                          : '$2'.
+     fun_arg -> '-' literal                                                                          : list_to_binary(["-",'$2']).
+```
+
+- **identified**
+
+```
+New: identified -> IDENTIFIED            BY NAME                                                     : {'identified by',       unwrap_bin('$3')}.
+     identified -> IDENTIFIED EXTERNALLY                                                             : {'identified extern',   []}.
+     identified -> IDENTIFIED EXTERNALLY AS NAME                                                     : {'identified extern',   unwrap_bin('$4')}.
+     identified -> IDENTIFIED GLOBALLY                                                               : {'identified globally', []}.
+     identified -> IDENTIFIED GLOBALLY   AS NAME                                                     : {'identified globally', unwrap_bin('$4')}.
+ 
+Old: identified -> IDENTIFIED BY NAME                                                                : {'identified by', unwrap_bin('$3')}.
+     identified -> IDENTIFIED EXTERNALLY opt_as                                                      : {'identified extern', '$3'}.
+     identified -> IDENTIFIED GLOBALLY opt_as                                                        : {'identified globally', '$3'}.
+     
+     opt_as -> '$empty'                                                                              : {}.
+     opt_as -> AS NAME                                                                               : {'as', unwrap_bin('$2')}.
+```
+
+- **in_predicate**
+
+```
+New: in_predicate -> scalar_exp NOT IN '(' subquery ')'                                              : {'not in', '$1', '$5'}.
+     in_predicate -> scalar_exp NOT IN '(' scalar_exp_commalist ')'                                  : {'not in', '$1', {list, '$5'}}.
+     in_predicate -> scalar_exp NOT IN scalar_exp_commalist                                          : {'not in', '$1', {list, '$4'}}.
+ 
+Old: in_predicate -> scalar_exp NOT IN '(' subquery ')'                                              : {'not', {'in', '$1', '$5'}}.
+     in_predicate -> scalar_exp NOT IN '(' scalar_exp_commalist ')'                                  : {'not', {'in', '$1', {'list', '$5'}}}.
+     in_predicate -> scalar_exp NOT IN scalar_exp_commalist                                          : {'not', {'in', '$1', {'list', '$4'}}}.
+
+```
+
+- **join_list**
+
+```
+New: join -> inner_cross_join                                                                        : '$1'.
+     join -> outer_join                                                                              : '$1'.
+     
+     join_list ->           join                                                                     :        ['$1'].
+     join_list -> join_list join                                                                     : '$1'++ ['$2'].
+ 
+Old: join_list -> inner_cross_join                                                                   : ['$1'].
+     join_list -> outer_join                                                                         : ['$1'].
+     join_list -> join_list join_list                                                                : '$1'++'$2'.
+```
+
+- **join_ref**
+
+```
+New: join_ref -> '(' query_exp ')'                                                                   : {'$2', "("}.
+     join_ref -> '(' query_exp ')' AS NAME                                                           : {as, {'$2', "("}, unwrap_bin('$5'), " as "}.
+     join_ref -> '(' query_exp ')'    NAME                                                           : {as, {'$2', "("}, unwrap_bin('$4'), " "}.
+ 
+Old: join_ref -> '(' query_exp ')'                                                                   : '$2'.
+     join_ref -> '(' query_exp ')' AS NAME                                                           : {as,'$2',unwrap_bin('$5')}.
+     join_ref -> '(' query_exp ')' NAME                                                              : {as,'$2',unwrap_bin('$4')}.
+```
+
+- **like_predicate**
+
+```
+New: like_predicate -> scalar_exp NOT LIKE scalar_exp ESCAPE atom                                    : {'not like', '$1', '$4', '$6'}.
+     like_predicate -> scalar_exp NOT LIKE scalar_exp                                                : {'not like', '$1', '$4', []}.
+     like_predicate -> scalar_exp     LIKE scalar_exp ESCAPE atom                                    : {like,       '$1', '$3', '$5'}.
+     like_predicate -> scalar_exp     LIKE scalar_exp                                                : {like,       '$1', '$3', []}.
+ 
+Old: like_predicate -> scalar_exp NOT LIKE scalar_exp opt_escape                                     : {'not', {'like', '$1', '$4', '$5'}}.
+     like_predicate -> scalar_exp LIKE scalar_exp opt_escape                                         : {'like', '$1', '$3', '$4'}.
+     
+     opt_escape -> '$empty'                                                                          : <<>>.
+     opt_escape -> ESCAPE atom                                                                       : '$2'.
+```
+
+- **opt_on_obj_clause**
+
+```
+New: opt_on_obj_clause -> ON JAVA SOURCE table                                                       : {'on java source', '$4'}.
+     opt_on_obj_clause -> ON JAVA RESOURCE table                                                     : {'on java resource', '$4'}.
+  
+Old: opt_on_obj_clause -> ON JAVA SOURCE table                                                       : {'on java source', unwrap_bin('$4')}.
+     opt_on_obj_clause -> ON JAVA RESOURCE table                                                     : {'on java resource', unwrap_bin('$4')}.
+```
+
+- **query_partition_clause**
+
+```
+New: query_partition_clause -> PARTITION BY '(' scalar_exp_commalist ')'                             : {partition_by, '$4', "("}.
+     query_partition_clause -> PARTITION BY     scalar_exp_commalist                                 : {partition_by, '$3', []} .
+ 
+Old: query_partition_clause -> PARTITION BY '(' scalar_exp_commalist ')'                             : {partition_by, '$4'}.
+     query_partition_clause -> PARTITION BY scalar_exp_commalist                                     : {partition_by, '$3'}.
+```
+
+- **query_term**
+
+```
+New: query_term -> '(' query_exp ')'                                                                 : {'$2', "("}.
+ 
+Old: query_term -> '(' query_exp ')'                                                                 : '$2'.
+```
+
+- **scalar_opt_as_exp**
+
+```
+New: scalar_opt_as_exp -> scalar_exp    NAME                                                         : {as, '$1', unwrap_bin('$2'), " "}.
+     scalar_opt_as_exp -> scalar_exp AS NAME                                                         : {as, '$1', unwrap_bin('$3'), " as "}.
+ 
+Old: scalar_opt_as_exp -> scalar_exp NAME                                                            : {as, '$1', unwrap_bin('$2')}.
+     scalar_opt_as_exp -> scalar_exp AS NAME                                                         : {as, '$1', unwrap_bin('$3')}. 
+```
+
+- **scalar_sub_exp**
+
+```
+New: n/a
+ 
+Old: scalar_sub_exp -> '+' literal                                                                   : '$2'.
+     scalar_sub_exp -> '-' literal                                                                   : list_to_binary(["-",'$2']).
+```
+
+- **search_condition**
+
+```
+New: search_condition -> '(' search_condition ')'                                                    : {'$2', "("}.
+ 
+Old: search_condition -> '(' search_condition ')'                                                    : '$2'.
+```
+
+- **schema**
+
+```
+New: schema -> CREATE SCHEMA AUTHORIZATION NAME opt_schema_element_list                              : {'create schema authorization', unwrap_bin('$4'), '$5'}.
+ 
+Old: schema -> CREATE SCHEMA AUTHORIZATION user opt_schema_element_list                              : {'create schema authorization', '$4', '$5'}.
+```
+
+- **table**
+
+```
+New: table -> NAME AS NAME                                                                           : {as, unwrap_bin('$1'), unwrap_bin('$3'), " as "}.
+     table -> NAME    NAME                                                                           : {as, unwrap_bin('$1'), unwrap_bin('$2'), " "}.
+     table -> NAME '.' NAME AS NAME                                                                  : {as, list_to_binary([unwrap('$1'),".",unwrap('$3')]), unwrap_bin('$5'), " as "}.
+     table -> NAME '.' NAME    NAME                                                                  : {as, list_to_binary([unwrap('$1'),".",unwrap('$3')]), unwrap_bin('$4'), " "}.
+     table -> parameter    NAME                                                                      : {as, '$1', unwrap_bin('$2'), " "}.
+     table -> parameter AS NAME                                                                      : {as, '$1', unwrap_bin('$3'), " as "}.
+ 
+Old: table -> NAME AS NAME                                                                           : {as, unwrap_bin('$1'), unwrap_bin('$3')}.
+     table -> NAME NAME                                                                              : {as, unwrap_bin('$1'), unwrap_bin('$2')}.
+     table -> NAME '.' NAME AS NAME                                                                  : {as, list_to_binary([unwrap('$1'),".",unwrap('$3')]), unwrap_bin('$5')}.
+     table -> NAME '.' NAME NAME                                                                     : {as, list_to_binary([unwrap('$1'),".",unwrap('$3')]), unwrap_bin('$4')}.
+     table -> parameter NAME                                                                         : {as, '$1', unwrap_bin('$2')}.
+     table -> parameter AS NAME                                                                      : {as, '$1', unwrap_bin('$3')}.
+```
+
+- **table_ref**
+
+```
+New: table_ref -> '(' query_exp ')'                                                                  : {'$2', "("}.
+     table_ref -> '(' query_exp ')' AS NAME                                                          : {as, {'$2', "("}, unwrap_bin('$5'), " as "}.
+     table_ref -> '(' query_exp ')'    NAME                                                          : {as, {'$2', "("}, unwrap_bin('$4'), " "}.
+  
+Old: table_ref -> '(' query_exp ')'                                                                  : '$2'.
+     table_ref -> '(' query_exp ')' AS NAME                                                          : {as,'$2',unwrap_bin('$5')}.
+     table_ref -> '(' query_exp ')' NAME                                                             : {as,'$2',unwrap_bin('$4')}.
+```
+
+- **test_for_null**
+
+```
+New: test_for_null -> scalar_exp IS NOT NULLX                                                        : {'is not', '$1', <<"null">>}.
+ 
+Old: test_for_null -> scalar_exp IS NOT NULLX                                                        : {'not', {'is', '$1', <<"null">>}}.
+```
+
+- **view_def**
+
+```
+New: view_def -> CREATE VIEW table opt_column_commalist                                              : {'create view', '$3', '$4'}.
+     view_def -> AS query_spec                                                                       : {as, '$2', [],                   "as "}.
+     view_def -> AS query_spec WITH CHECK OPTION                                                     : {as, '$2', " with check option", "as "}.
+ 
+Old: view_def -> CREATE VIEW table opt_column_commalist                                              : {'create view', '$3', '$4'}.
+     view_def -> AS query_spec opt_with_check_option                                                 : {'as', '$2', '$3'}.
+        
+     opt_with_check_option -> '$empty'                                                               : [].
+     opt_with_check_option -> WITH CHECK OPTION                                                      : 'with check option'.
+```
+
+### Features modified
+
+- **ocparse_generator**: checking the result of performance common tests
+- **ocparse_test**: comparison of source code removed
+- **ocparse_test**: messages improved

--- a/priv/BNFC/sqlparse.cf
+++ b/priv/BNFC/sqlparse.cf
@@ -631,8 +631,8 @@ Table09.                          Table ::= Parameter      "NAME"         ;
 Table10.                          Table ::= Parameter "AS" "NAME"         ;
 
 ColumnRef01.                      ColumnRef ::=                       "JSON"             ;
-ColumnRef02.                      ColumnRef ::=            "NAME" "." "JSON"             ;
-ColumnRef03.                      ColumnRef ::= "NAME" "." "NAME" "." "JSON"             ;
+ColumnRef02.                      ColumnRef ::=            "NAME"     "JSON"             ;
+ColumnRef03.                      ColumnRef ::= "NAME" "." "NAME"     "JSON"             ;
 ColumnRef04.                      ColumnRef ::=                       "NAME"             ;
 ColumnRef05.                      ColumnRef ::=            "NAME" "." "NAME"             ;
 ColumnRef06.                      ColumnRef ::= "NAME" "." "NAME" "." "NAME"             ;

--- a/priv/grammar.ebnf
+++ b/priv/grammar.ebnf
@@ -170,8 +170,8 @@ create_index_spec -> '(' create_index_spec_items ')'                            
 
 create_index_spec_items -> NAME                                                                 : [unwrap_bin('$1')].
 create_index_spec_items -> NAME '|' create_index_spec_items                                     : [unwrap_bin('$1') | '$3'].
-create_index_spec_items -> JSON                                                                 : [jpparse('$1')].
-create_index_spec_items -> JSON '|' create_index_spec_items                                     : [jpparse('$1') | '$3'].
+create_index_spec_items -> JSON                                                                 : [{jp, jpparse('$1')}].
+create_index_spec_items -> JSON '|' create_index_spec_items                                     : [{jp, jpparse('$1')} | '$3'].
 
 create_index_opt_norm -> '$empty'                                                               : {}.
 create_index_opt_norm -> NORM_WITH STRING                                                       : {norm, unwrap_bin('$2')}.
@@ -1257,9 +1257,9 @@ table ::= ( ( NAME '.' )? NAME ( ( AS )? NAME )? )
         | ( parameter ( ( AS )? NAME )? )
 
 /* =============================================================================
-column_ref -> JSON                                                                              : jpparse('$1').
-column_ref -> NAME '.' JSON                                                                     : [unwrap('$1'),".",jpparse('$3')].
-column_ref -> NAME '.' NAME '.' JSON                                                            : [unwrap('$1'),".",unwrap('$3'),".",jpparse('$5')].
+column_ref -> JSON                                                                              : {jp, jpparse('$1')}.
+column_ref -> NAME     JSON                                                                     : {list_to_binary(unwrap('$1')), {jp,jpparse('$2')}}.
+column_ref -> NAME '.' NAME     JSON                                                            : {list_to_binary([unwrap('$1'),".",unwrap('$3')]), {jp,jpparse('$4')}}.
 column_ref -> NAME                                                                              : unwrap_bin('$1').
 column_ref -> NAME '.' NAME                                                                     : list_to_binary([unwrap('$1'),".",unwrap('$3')]).
 column_ref -> NAME '.' NAME '.' NAME                                                            : list_to_binary([unwrap('$1'),".",unwrap('$3'),".",unwrap('$5')]).
@@ -1270,7 +1270,8 @@ column_ref -> NAME '.' '*'                                                      
 column_ref -> NAME '.' NAME '.' '*'                                                             : list_to_binary([unwrap('$1'),".",unwrap('$3'),".*"]).
 ============================================================================= */
 
-column_ref ::= ( ( ( NAME '.' )? NAME '.' )? ( JSON | NAME ) )
+column_ref ::= ( ( ( NAME '.' )? NAME )? JSON )
+             | ( ( ( NAME '.' )? NAME '.' )? NAME )
              | ( ( ( NAME '.' )? NAME '.' )? NAME '(' '+' ')' )
              | ( ( NAME '.' )? NAME '.' '*' )
 

--- a/src/sql_lex.xrl
+++ b/src/sql_lex.xrl
@@ -41,8 +41,7 @@ Rules.
 ([\|\-\+\*\/\(\)\,\.\;]|(\|\|)|(div))               : {token, {list_to_atom(TokenChars), TokenLine}}.
 
 % JSON
-% (JSON[A-Za-z0-9_\.]+([:#\[\{]+|([\s\t\n\r]*[#\[\{]+))[A-Za-z0-9_\.\:\(\)\[\]\{\}\#\,\|\-\+\*\/\\%\s\t\n\r]*)
-(\|[\.:{\[#]([^\|]*)+\|)                            : parse_json(TokenLine, TokenChars).
+(\|[:{\[#]([^\|]*)+\|)                              : parse_json(TokenLine, TokenChars).
 
 % names
 [A-Za-z][A-Za-z0-9_@:#\$]*                          : match_any(TokenChars, TokenLen, TokenLine, ?TokenPatters).

--- a/src/sqlparse.yrl
+++ b/src/sqlparse.yrl
@@ -441,8 +441,8 @@ create_index_spec -> '(' create_index_spec_items ')'                            
 
 create_index_spec_items -> NAME                                                                 : [unwrap_bin('$1')].
 create_index_spec_items -> NAME '|' create_index_spec_items                                     : [unwrap_bin('$1') | '$3'].
-create_index_spec_items -> JSON                                                                 : [jpparse('$1')].
-create_index_spec_items -> JSON '|' create_index_spec_items                                     : [jpparse('$1') | '$3'].
+create_index_spec_items -> JSON                                                                 : [{jp, jpparse('$1')}].
+create_index_spec_items -> JSON '|' create_index_spec_items                                     : [{jp, jpparse('$1')} | '$3'].
 
 create_index_opt_norm -> '$empty'                                                               : {}.
 create_index_opt_norm -> NORM_WITH STRING                                                       : {norm, unwrap_bin('$2')}.
@@ -687,12 +687,12 @@ table_name -> NAME '.' NAME                                                     
 table_name -> NAME '.' NAME '.' NAME                                                            : list_to_binary([unwrap('$1'),".",unwrap('$3'),".",unwrap('$5')]).
 
 opt_materialized -> '$empty'                                                                    : {}.
-opt_materialized -> PRESERVE MATERIALIZED VIEW LOG                                              : {'materialized view log', 'preserve'}.
-opt_materialized -> PURGE MATERIALIZED VIEW LOG                                                 : {'materialized view log', 'purge'}.
+opt_materialized -> PRESERVE MATERIALIZED VIEW LOG                                              : {'materialized view log', preserve}.
+opt_materialized -> PURGE MATERIALIZED VIEW LOG                                                 : {'materialized view log', purge}.
 
 opt_storage ->  '$empty'                                                                        : {}.
-opt_storage ->  DROP  STORAGE                                                                   : {storage, 'drop'}.
-opt_storage ->  REUSE STORAGE                                                                   : {storage, 'reuse'}.
+opt_storage ->  DROP  STORAGE                                                                   : {storage, drop}.
+opt_storage ->  REUSE STORAGE                                                                   : {storage, reuse}.
 
 close_statement -> CLOSE cursor                                                                 : {close, '$2'}.
 
@@ -941,9 +941,9 @@ in_predicate -> scalar_exp     IN scalar_exp_commalist                          
 
 all_or_any_predicate -> scalar_exp COMPARISON any_all_some subquery                             : {unwrap('$2'), '$1', {'$3', ['$4']}}.
 
-any_all_some -> ANY                                                                             : 'any'.
-any_all_some -> ALL                                                                             : 'all'.
-any_all_some -> SOME                                                                            : 'some'.
+any_all_some -> ANY                                                                             : any.
+any_all_some -> ALL                                                                             : all.
+any_all_some -> SOME                                                                            : some.
 
 existence_test -> EXISTS subquery                                                               : {exists, '$2'}.
 
@@ -1034,9 +1034,9 @@ table -> parameter                                                              
 table -> parameter    NAME                                                                      : {as, '$1', unwrap_bin('$2'), " "}.
 table -> parameter AS NAME                                                                      : {as, '$1', unwrap_bin('$3'), " as "}.
 
-column_ref -> JSON                                                                              : jpparse('$1').
-column_ref -> NAME '.' JSON                                                                     : [unwrap('$1'),".",jpparse('$3')].
-column_ref -> NAME '.' NAME '.' JSON                                                            : [unwrap('$1'),".",unwrap('$3'),".",jpparse('$5')].
+column_ref -> JSON                                                                              : {jp, jpparse('$1')}.
+column_ref -> NAME     JSON                                                                     : {jp, list_to_binary(unwrap('$1')), jpparse('$2')}.
+column_ref -> NAME '.' NAME     JSON                                                            : {jp, list_to_binary([unwrap('$1'),".",unwrap('$3')]), jpparse('$4')}.
 column_ref -> NAME                                                                              : unwrap_bin('$1').
 column_ref -> NAME '.' NAME                                                                     : list_to_binary([unwrap('$1'),".",unwrap('$3')]).
 column_ref -> NAME '.' NAME '.' NAME                                                            : list_to_binary([unwrap('$1'),".",unwrap('$3'),".",unwrap('$5')]).

--- a/test/index.tst
+++ b/test/index.tst
@@ -19,7 +19,7 @@
 "create index a on b (a:d)".
 "create index a on b (a:d|e:f)".
 "create index a on b (f) norm_with fun() -> norm end.".
-"create index a on b (a | |.d{}|) norm_with fun() -> norm end. filter_with fun mod:modfun/5.".
+"create index a on b (a | |:d{}|) norm_with fun() -> norm end. filter_with fun mod:modfun/5.".
 "create index name_sort on skvhACCOUNT (cvalue:NAME) norm_with fun imem_index:vnf_lcase_ascii/1. filter_with fun imem_index:iff_binterm_list_1/1.".
 
 

--- a/test/jsonpath.tst
+++ b/test/jsonpath.tst
@@ -8,11 +8,11 @@
 %% TESTS
 %%
 
-"select |.a:b| from x".
-"select |.a::b| from x".
-"select |.a[]| from x".
-"select |.a {}| from x".
-"select |.a:f()| from x".
-"select |.a:b[f(p:q)]| from x".
-"select |.a.g:b.f[f(p.r:q)]| from x".
-"select |.a.g:b.f\n[\tf(p.r:q)]| from x".
+"select a|:b| from x".
+"select a|::b| from x".
+"select a|[]| from x".
+"select a|{}| from x".
+"select a|:f()| from x".
+"select a|:b[f(p:q)]| from x".
+"select a.g|:b.f[f(p.r:q)]| from x".
+"select a.g|:b.f\n[\tf(p.r:q)]| from x".

--- a/test/sqlparse_test.erl
+++ b/test/sqlparse_test.erl
@@ -231,7 +231,7 @@ eunit_test_source(_TestGroup, Source, Logs) ->
                              NS_TD ->
                                  NS_TD
                          end,
-            ?debugFmt(?MODULE_STRING ++ ":eunit_test_source ===>~NewSource = ~tp~n", [NSource_TD]),
+            % wwe ?debugFmt(?MODULE_STRING ++ ":eunit_test_source ===>~NewSource = ~tp~n", [NSource_TD]),
             ?D3("~n[TD] NewSource~n~s", [NSource_TD]),
             %% -----------------------------------------------------------------
             %% 3. Source (=NSource_TD) ==> ParseTree (=NPT_TD)


### PR DESCRIPTION
- `\.` removed from lexer definition,
- grammar definition: 
```
column_ref -> NAME     JSON
column_ref -> NAME '.' NAME     JSON,
```
- parse tree entry starts with `{jp`.